### PR TITLE
hotfix: allow all posts and comment access

### DIFF
--- a/src/collections/Boards.ts
+++ b/src/collections/Boards.ts
@@ -78,10 +78,10 @@ export const checkBoardAdminAccess: Access & FieldAccess = async ({
 const Boards: CollectionConfig = {
 	slug: "boards",
 	access: {
-		read: checkBoardAccess,
-		create: checkBoardAdminAccess,
-		update: checkBoardAdminAccess,
-		delete: checkBoardAdminAccess,
+		read: () => true,
+		create: () => true,
+		update: () => true,
+		delete: () => true,
 	},
 	labels: {
 		singular: "유저 게시판",

--- a/src/collections/Posts.ts
+++ b/src/collections/Posts.ts
@@ -95,10 +95,10 @@ export const checkPostAccess =
 const Posts: CollectionConfig = {
 	slug: "posts",
 	access: {
-		read: checkPostAccess("read"),
-		create: checkPostAccess("create"),
-		update: checkPostAccess("update"),
-		delete: ({ req }) => !!req.user,
+		read: () => true,
+		create: () => true,
+		update: () => true,
+		delete: () => true,
 	},
 	hooks: {
 		beforeValidate: [


### PR DESCRIPTION
This pull request simplifies the access control logic for the `Boards` and `Posts` collections by replacing specific access checks with universally permissive access rules. These changes make all operations (`read`, `create`, `update`, `delete`) accessible to everyone.

Simplified access control:

* [`src/collections/Boards.ts`](diffhunk://#diff-4a725530d2b3cef328d6fb7119200466e2cb8dc2ff146255a5a1dc3733521c0cL81-R84): Replaced the `checkBoardAccess` and `checkBoardAdminAccess` functions with `() => true` for all access operations (`read`, `create`, `update`, `delete`), allowing unrestricted access to the `Boards` collection.
* [`src/collections/Posts.ts`](diffhunk://#diff-e5fcdf356f97a9b466c5c0bfedf5f97ae17632e8c307d8080c9b59c58a1a3458L98-R101): Replaced the `checkPostAccess` function and a user-specific delete check with `() => true` for all access operations (`read`, `create`, `update`, `delete`), allowing unrestricted access to the `Posts` collection.